### PR TITLE
Support for latest release of Sensor Tag

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,7 +73,7 @@ util.inherits(SensorTag, events.EventEmitter);
 
 SensorTag.discover = function(callback, uuid) {
   var onDiscover = function(peripheral) {
-    if (peripheral.advertisement.localName === 'SensorTag' &&
+    if (peripheral.advertisement.localName.match(/Sensor {0,1}Tag/) &&
         ( uuid === undefined || uuid === peripheral.uuid )) {
       noble.removeListener('discover', onDiscover);
       noble.stopScanning();


### PR DESCRIPTION
My sensor tag (delivered today) reports a different name "TI BLE Sensor Tag". With this change both are matched.
