### PR TITLE
Fixed lux and relative humidity readings using TI's Android source code

### DIFF
--- a/lib/cc2650.js
+++ b/lib/cc2650.js
@@ -55,7 +55,12 @@ CC2650SensorTag.prototype.convertIrTemperatureData = function(data, callback) {
 
 CC2650SensorTag.prototype.convertHumidityData = function(data, callback) {
   var temperature = -40 + ((165  * data.readUInt16LE(0)) / 65536.0);
-  var humidity = data.readUInt16LE(2) * 100 / 65536.0;
+  // Caleb Piekstra
+  // Relative humidity - Updated to match TI Android code
+  // tested and working with sensortag firmware version 1.01
+  var a = data.readUInt16LE(2);
+  a = a - (a % 4);
+  var humidity = (-6.0) + 125.0 * (a / 65535.0);
 
   callback(temperature, humidity);
 };
@@ -299,9 +304,21 @@ CC2650SensorTag.prototype.onLuxometerChange = function(data) {
 };
 
 CC2650SensorTag.prototype.convertLuxometerData = function(data, callback) {
-  var lux = data.readUInt16LE(0) /100;
+  // Caleb Piekstra
+  // Updated to match TI Android code 
+  // tested and working with sensortag firmware version 1.01
+  var mantissa;
+  var exponent;
+  var sfloat= shortUnsignedAtOffset(data, 0);
 
-  callback(lux);
+  mantissa = sfloat & 0x0FFF;
+  exponent = (sfloat >> 12) & 0xFF;
+
+  var output;
+  var magnitude = Math.pow(2.0, exponent);
+  output = (mantissa * magnitude);
+ 
+  callback(output/100.0);
 };
 
 CC2650SensorTag.prototype.notifyLuxometer = function(callback) {


### PR DESCRIPTION
This causes the readings to match up with the Android application's reported values for lux and humidity. The reading differences were fairly minimal so it's possible the app itself is incorrect.