### PR TITLE
Barometric Pressure depending on the firmware version

### DIFF
--- a/lib/cc2650.js
+++ b/lib/cc2650.js
@@ -65,14 +65,34 @@ CC2650SensorTag.prototype.enableBarometricPressure = function(callback) {
 };
 
 CC2650SensorTag.prototype.convertBarometricPressureData = function(data, callback) {
-  var tempBMP = data.readUInt16LE(0);
+  // data is returned as 
+  // Firmare 0.89 16 bit single precision float
+  // Firmare 1.01 24 bit single precision float
 
-  var exponent = (tempBMP & 0xf000) >> 12;
-  var mantissa = (tempBMP & 0x0fff);
+  var tempBMP;     // Temperature processed value from sensor
+  var pressure; // Pressure processed value from sensor
 
-  var flTempBMP = mantissa * Math.pow(2, exponent) / 10000.0;
-  var flPressure = ((data.readUInt32LE(2) >> 8) & 0x00ffffff) / 100.0;
 
+  // Firmware 1.01 
+  if (data.length > 4) {
+	  flTempBMP = (data.readUInt32LE(0) & 0x00ffffff)/ 100.0;
+	  flPressure = ((data.readUInt32LE(2) >> 8) & 0x00ffffff) / 100.0;
+  }
+  // Firmware 0.89
+  else {
+	  tempBMP = data.readUInt16LE(0);
+	  exponent = (tempBMP & 0xF000) >> 12;
+	  mantissa = (tempBMP & 0x0FFF);
+	  flTempBMP = mantissa * Math.pow(2, exponent) / 100.0;
+	  
+	  pressure = data.readUInt16LE(2);
+	  exponent = (pressure & 0xF000) >> 12;
+	  mantissa = (pressure & 0x0FFF);
+	  flPressure = mantissa * Math.pow(2, exponent) / 100.0;
+  }
+  console.log('temperature ' + flTempBMP);
+  console.log('pressure ' + flPressure);
+  callback(flPressure);
   callback(flPressure);
 };
 

--- a/lib/cc2650.js
+++ b/lib/cc2650.js
@@ -93,7 +93,6 @@ CC2650SensorTag.prototype.convertBarometricPressureData = function(data, callbac
   console.log('temperature ' + flTempBMP);
   console.log('pressure ' + flPressure);
   callback(flPressure);
-  callback(flPressure);
 };
 
 CC2650SensorTag.prototype.setMPU9250Period = function(period, callback) {

--- a/lib/cc2650.js
+++ b/lib/cc2650.js
@@ -294,9 +294,12 @@ CC2650SensorTag.prototype.onLuxometerChange = function(data) {
 };
 
 CC2650SensorTag.prototype.convertLuxometerData = function(data, callback) {
-  var lux = data.readUInt16LE(0) /100;
-
-  callback(lux);
+  var lux = data.readUInt16LE(0);
+  var flLux;
+  exponent = (lux & 0xF000) >> 12;
+  mantissa = (lux & 0x0FFF);
+  flLux = mantissa * Math.pow(2, exponent) / 100.0;
+  callback(flLux);
 };
 
 CC2650SensorTag.prototype.notifyLuxometer = function(callback) {


### PR DESCRIPTION
TI SensorTag CC2650STK returns 16 bit values (firmware 0.89) or 24 bit values (firmware 1.01).