### PR TITLE
Ignore case and colon for discoverByUuid

### DIFF
--- a/lib/sensortag.js
+++ b/lib/sensortag.js
@@ -25,8 +25,9 @@ SensorTag.discover = function(callback) {
 };
 
 SensorTag.discoverByUuid = function(uuid, callback) {
+  var uuid_filtered = uuid.toLowerCase().replace(/\:/g,'');
   var onDiscoverByUuid = function(sensorTag) {
-    if (sensorTag.uuid === uuid) {
+    if (sensorTag.uuid === uuid_filtered) {
       SensorTag.stopDiscoverAll(onDiscoverByUuid);
 
       callback(sensorTag);

--- a/lib/sensortag.js
+++ b/lib/sensortag.js
@@ -25,9 +25,8 @@ SensorTag.discover = function(callback) {
 };
 
 SensorTag.discoverByUuid = function(uuid, callback) {
-  var uuid_filtered = uuid.toLowerCase().replace(/\:/g,'');
   var onDiscoverByUuid = function(sensorTag) {
-    if (sensorTag.uuid === uuid_filtered) {
+    if (sensorTag.uuid === uuid) {
       SensorTag.stopDiscoverAll(onDiscoverByUuid);
 
       callback(sensorTag);
@@ -35,6 +34,11 @@ SensorTag.discoverByUuid = function(uuid, callback) {
   };
 
   SensorTag.discoverAll(onDiscoverByUuid);
+};
+
+SensorTag.discoverByAddress = function(address, callback) {
+  var uuid = address.toLowerCase().replace(/\:/g,'');
+  SensorTag.discoverByUuid(uuid, callback);
 };
 
 SensorTag.CC2540 = CC2540SensorTag;


### PR DESCRIPTION
Added conversion for input UUID so that colons are removed and the case matches the UUID returned by noble.