### PR TITLE
Reduce the lower limit of sensor updating period from 100 ms to 10 ms.

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -37,8 +37,8 @@ SensorTagCommon.prototype.toString = function() {
 SensorTagCommon.prototype.writePeriodCharacteristic = function(serviceUuid, characteristicUuid, period, callback) {
   period /= 10; // input is scaled by units of 10ms
 
-  if (period < 10) {
-    period = 10;
+  if (period < 1) {
+    period = 1;
   } else if (period > 255) {
     period = 255;
   }


### PR DESCRIPTION
The sensortag firmware already checks the lower limit so there is no need to do it here. This also accommodates custom firmwares that can send sensor data faster than 10 Hz.