### PR TITLE
Added functionality to read the battery level from the CC2650

### DIFF
--- a/lib/cc2650.js
+++ b/lib/cc2650.js
@@ -8,6 +8,7 @@ var MPU9250_UUID                            = 'f000aa8004514000b000000000000000'
 var BAROMETRIC_PRESSURE_UUID                = 'f000aa4004514000b000000000000000';
 var IO_UUID                                 = 'f000aa6404514000b000000000000000';
 var LUXOMETER_UUID                          = 'f000aa7004514000b000000000000000';
+var BATTERY_UUID                            = '180f';
 
 var BAROMETRIC_PRESSURE_CONFIG_UUID         = 'f000aa4204514000b000000000000000';
 
@@ -25,6 +26,8 @@ var IO_CONFIG_UUID                          = 'f000aa6604514000b000000000000000'
 var LUXOMETER_CONFIG_UUID                   = 'f000aa7204514000b000000000000000';
 var LUXOMETER_DATA_UUID                     = 'f000aa7104514000b000000000000000';
 var LUXOMETER_PERIOD_UUID                   = 'f000aa7304514000b000000000000000';
+
+var BATTERY_LEVEL_DATA_UUID                 = '2a19';
 
 var CC2650SensorTag = function(peripheral) {
   NobleDevice.call(this, peripheral);
@@ -342,6 +345,16 @@ CC2650SensorTag.prototype.convertSimpleKeyData = function(data, callback) {
   var reedRelay = (b & 0x4) ? true : false;
 
   callback(left, right, reedRelay);
+};
+
+CC2650SensorTag.prototype.readBatteryLevel = function(callback) {
+  this.readDataCharacteristic(BATTERY_UUID, BATTERY_LEVEL_DATA_UUID, function(error, data) {
+    if (error) {
+      return callback(error);
+    }
+
+    callback(data);
+  }.bind(this));
 };
 
 module.exports = CC2650SensorTag;


### PR DESCRIPTION
Since one of the latest firmware updates it's possible to read the battery power level and therefore I've added this functionality to the CC2650.js
